### PR TITLE
api link fix

### DIFF
--- a/control/content/index.html
+++ b/control/content/index.html
@@ -33,7 +33,7 @@
             <label>Open Weather Map API Key
             </label>
             <span class="customTooltipBox btn-primary">
-                <a href="https://openweathermap.org">
+                <a href="https://openweathermap.org" target="_blank">
                     <span class="customTooltipText">
                         Click here to get Open Weather API Key
                       </span>


### PR DESCRIPTION
When you click on tooltip on CP regarding open weather API, if you click it would open website inside of CP